### PR TITLE
feat: refresh oauth2 tokens on auth change

### DIFF
--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -21,6 +21,7 @@ export interface BaseOAuth2Token {
   // Should be Date.now() if valid
   // Debug
   xResponseId: string | null;
+  xAuthHash: string | null;
   xError: string | null;
   // Error handling
   error: string;
@@ -41,6 +42,7 @@ export function init(): BaseOAuth2Token {
     // Should be Date.now() if valid
     // Debug
     xResponseId: null,
+    xAuthHash: null,
     xError: null,
     // Error handling
     error: '',

--- a/packages/insomnia/src/network/o-auth-2/constants.ts
+++ b/packages/insomnia/src/network/o-auth-2/constants.ts
@@ -29,6 +29,7 @@ export type AuthKeys =
     'token_type' |
     'username' |
     'xError' |
-    'xResponseId';
+    'xResponseId' |
+    'xAuthHash';
 export const PKCE_CHALLENGE_S256 = 'S256';
 export const PKCE_CHALLENGE_PLAIN = 'plain';


### PR DESCRIPTION
when the authentication details used to retrieve an oauth2 token change we need to retrieve a new token
this change makes it so that insomnia automatically disregards existing oauth2 tokens that were created with different authentication details

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
